### PR TITLE
📚 Automates the build of docs on GH pages

### DIFF
--- a/.github/workflows/docs2gh.yml
+++ b/.github/workflows/docs2gh.yml
@@ -1,0 +1,34 @@
+name: Building documentation as gh-pages
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build_docs:
+    name: documentation
+    runs-on: ubuntu-latest # ${{ matrix.platform }}
+
+    steps:
+      # Checkout the repository and setups the machine to use python
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: generates API documentation
+        # You may not run this step if done locally and the documentation was updated manually
+        # (and those files committed to the repository)
+        run: |
+          pip install sphinx
+          cd docs
+          sphinx-apidoc -o . ../sagittal_average
+      - name: Build and Commit
+        uses: sphinx-notes/pages@v2
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,9 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 
 # -- Project information -----------------------------------------------------
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.coverage', # Automatically check if functions are documented
     'sphinx.ext.mathjax',  # Allow support for algebra
     'sphinx.ext.viewcode', # Include the source code in documentation
+    'sphinx.ext.githubpages', # Publish HTML docs in GitHub Pages¶
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
It adds the gh-action configuration to build the documentation on the
github-pages branch (only when merged in the main branch)

Note, that to make it work on your repository you need [to enable github pages in the settings of the repository](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site)

(step 4 from UCL-COMP0233-22-23/RSE-Classwork#46)